### PR TITLE
Close #61

### DIFF
--- a/app/models/data_processor.rb
+++ b/app/models/data_processor.rb
@@ -55,34 +55,34 @@ module DataProcessor
 
   def assign_data_to_url(data)
     url_data = assign_url_data(data)
-    url = Url.create(root_url: url_data[:root], path: url_data[:path])
+    url = Url.find_or_create_by(root_url: url_data[:root], path: url_data[:path])
     url.id
   end
 
   def assign_data_to_referred_by(data)
     url_data = assign_url_data(data)
-    refer = ReferredBy.create(root_url: url_data[:root], path: url_data[:path])
+    refer = ReferredBy.find_or_create_by(root_url: url_data[:root], path: url_data[:path])
     refer.id
   end
 
   def assign_data_to_request_type(data)
-    type = RequestType.create(name: data[:request_type])
+    type = RequestType.find_or_create_by(name: data[:request_type])
     type.id
   end
 
   def assign_data_to_user_agent(data)
     agent = UserAgent.parse(data[:user_agent])
-    u_agent = UAgent.create(browser: agent.browser, operating_system: agent.platform)
+    u_agent = UAgent.find_or_create_by(browser: agent.browser, operating_system: agent.platform)
     u_agent.id
   end
 
   def assign_data_to_resolution(data)
-    res = Resolution.create(width: data[:resolution_width], height: data[:resolution_height])
+    res = Resolution.find_or_create_by(width: data[:resolution_width], height: data[:resolution_height])
     res.id
   end
 
   def assign_data_to_ip(data)
-    ip = Ip.create(address: data[:ip])
+    ip = Ip.find_or_create_by(address: data[:ip])
     ip.id
   end
 

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -4,7 +4,7 @@ class RequestType < ActiveRecord::Base
   validates :name, presence: true
 
   def self.most_frequent_request_type
-    verbs = RequestType.pluck(:name)
+    verbs = RequestType.pluck(:name).sort
     verb_count = verbs.each_with_object(Hash.new(0)) { |verb, hash| hash[verb] += 1 }
     verb_count.max_by { |verb, count| count }.first
   end

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -2,4 +2,14 @@ class RequestType < ActiveRecord::Base
   has_many :payload_requests
 
   validates :name, presence: true
+
+  def self.most_frequent_request_type
+    verbs = RequestType.pluck(:name)
+    verb_count = verbs.each_with_object(Hash.new(0)) { |verb, hash| hash[verb] += 1 }
+    verb_count.max_by { |verb, count| count }.first
+  end
+
+  def self.all_request_types
+    RequestType.pluck(:name).uniq
+  end
 end

--- a/app/models/resolution.rb
+++ b/app/models/resolution.rb
@@ -4,9 +4,11 @@ class Resolution < ActiveRecord::Base
   validates :width, presence: true
   validates :height, presence: true
 
-  # def self.resolutions
-  #   all.map do |object|
-  #     object.width * object.height
-  #   end
-  # end
+  def self.resolutions
+    resolutions = Hash.new(0)
+    all.each do |object|
+      resolutions[object.width * object.height] += 1
+    end
+    resolutions
+  end
 end

--- a/app/models/resolution.rb
+++ b/app/models/resolution.rb
@@ -5,10 +5,11 @@ class Resolution < ActiveRecord::Base
   validates :height, presence: true
 
   def self.resolutions
-    resolutions = Hash.new(0)
-    all.each do |object|
-      resolutions[object.width * object.height] += 1
-    end
-    resolutions
+    all.map do |object|
+      count = PayloadRequest.where(resolution_id: object.id).count
+      res = object.width * object.height
+      [res, count]
+    end.to_h
   end
+
 end

--- a/test/models/data_processor_test.rb
+++ b/test/models/data_processor_test.rb
@@ -74,4 +74,17 @@ class DataProcessorTest < Minitest::Test
     assert_equal 1, loaded.u_agent_id
     assert_equal 1, loaded.referred_by_id
   end
+
+  def test_it_does_not_store_duplicate_entires_within_foreign_key_tables
+    process_payload(raw_data)
+    process_payload(raw_data)
+
+    assert_equal 2, PayloadRequest.count
+    assert_equal 1, Url.all.count
+    assert_equal 1, RequestType.all.count
+    assert_equal 1, Resolution.all.count
+    assert_equal 1, Ip.all.count
+    assert_equal 1, UAgent.all.count
+    assert_equal 1, ReferredBy.all.count
+  end
 end

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper.rb'
+require 'pry'
 
 class RequestTypeTest < Minitest::Test
   include TestHelpers
@@ -9,6 +10,21 @@ class RequestTypeTest < Minitest::Test
     assert request_type.valid?
     request_type = RequestType.create({})
     refute request_type.valid?
+  end
+
+  def test_returns_all_request_types
+    RequestType.create(name: "GET")
+    RequestType.create(name: "POST")
+    RequestType.create(name: "GET")
+    assert_equal 3, RequestType.all.count
+    assert_equal ["GET", "POST"], RequestType.all_request_types
+  end
+
+  def test_returns_most_frequent_request_type
+    RequestType.create(name: "GET")
+    RequestType.create(name: "POST")
+    RequestType.create(name: "POST")
+    assert_equal "POST", RequestType.most_frequent_request_type
   end
 
 end

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -1,5 +1,4 @@
 require_relative '../test_helper.rb'
-require 'pry'
 
 class RequestTypeTest < Minitest::Test
   include TestHelpers

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -21,10 +21,10 @@ class RequestTypeTest < Minitest::Test
   end
 
   def test_returns_most_frequent_request_type
-    RequestType.create(name: "GET")
-    RequestType.create(name: "POST")
     RequestType.create(name: "POST")
     assert_equal "POST", RequestType.most_frequent_request_type
+    RequestType.create(name: "GET")
+    assert_equal "GET", RequestType.most_frequent_request_type
   end
 
 end

--- a/test/models/resolution_test.rb
+++ b/test/models/resolution_test.rb
@@ -10,11 +10,13 @@ class ResolutionTest < Minitest::Test
     assert resolution.valid?
   end
 
-  # def test_it_can_display_all_screen_resolutions
-  #   res_1 = {:width => 1280, :height => 800}
-  #   res_2 = {:width => 1024, :height => 768}
-  #   Resolution.create(res_1)
-  #   Resolution.create(res_2)
-  #   assert_equal [1024000, 786432], Resolution.resolutions
-  # end
+  def test_it_can_display_all_screen_resolutions
+    res_1 = {:width => 1280, :height => 800}
+    res_2 = {:width => 1024, :height => 768}
+    Resolution.create(res_1)
+    Resolution.create(res_2)
+    Resolution.create(res_1)
+    expected = {1024000 => 2, 786432 => 1}
+    assert_equal expected, Resolution.resolutions
+  end
 end

--- a/test/models/resolution_test.rb
+++ b/test/models/resolution_test.rb
@@ -1,7 +1,21 @@
 require_relative '../test_helper.rb'
 
 class ResolutionTest < Minitest::Test
-  include TestHelpers
+  include TestHelpers, DataProcessor
+
+  def raw_data
+    '{
+      "url": "http://jumpstartlab.com/blog",
+      "requestedAt": "2013-02-16 21:38:28 -0700",
+      "respondedIn": 37,
+      "referredBy": "http://jumpstartlab.com",
+      "requestType": "GET",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
+      "resolutionWidth": "1920",
+      "resolutionHeight": "1280",
+      "ip": "63.29.38.211"
+     }'
+  end
 
   def test_it_can_hold_width_and_height
     resolution = Resolution.create(width: 1280, height: 800)
@@ -11,12 +25,9 @@ class ResolutionTest < Minitest::Test
   end
 
   def test_it_can_display_all_screen_resolutions
-    res_1 = {:width => 1280, :height => 800}
-    res_2 = {:width => 1024, :height => 768}
-    Resolution.create(res_1)
-    Resolution.create(res_2)
-    Resolution.create(res_1)
-    expected = {1024000 => 2, 786432 => 1}
+    process_payload(raw_data)
+    process_payload(raw_data)
+    expected = {2457600 => 2}
     assert_equal expected, Resolution.resolutions
   end
 end


### PR DESCRIPTION
Fixes bug that allowed duplicate entries to be stored in our tables referenced by foreign keys in PayloadRequest (Url, Ip, etc.)
